### PR TITLE
Add server hashing for isomorphic environments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/array-type": "off",
+    "@typescript-eslint/no-var-requires": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [
       "warn",

--- a/scripts/setupTests.ts
+++ b/scripts/setupTests.ts
@@ -3,5 +3,8 @@ import { Crypto } from '@peculiar/webcrypto';
 // Polyfills for functionality not available in Node.js
 // TextEncoder
 require('fast-text-encoding');
-// WebCrypto
-(window as any).crypto = new Crypto();
+
+if (typeof window !== 'undefined') {
+  // WebCrypto
+  (window as any).crypto = new Crypto();
+}

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,18 +1,30 @@
 export function isCryptoSupported(): boolean {
-  return (
-    TextEncoder !== undefined &&
-    window.crypto !== undefined &&
-    window.crypto.subtle !== undefined
-  );
+  if (typeof window === 'undefined') {
+    return true;
+  } else {
+    return (
+      TextEncoder !== undefined &&
+      window.crypto !== undefined &&
+      window.crypto.subtle !== undefined
+    );
+  }
 }
 
 export async function sha256(input: string): Promise<string> {
-  const data = new TextEncoder().encode(input);
-  const digest = await window.crypto.subtle.digest('SHA-256', data);
-  const byteArray = new Uint8Array(digest);
-  const chars = new Array(byteArray.length);
-  byteArray.forEach((byte, index) => {
-    chars[index] = byte.toString(16).padStart(2, '0');
-  });
-  return chars.join('');
+  if (typeof window === 'undefined') {
+    const crypto = require('crypto');
+    const hash = crypto.createHash('sha256');
+    hash.update(input);
+    const digest = hash.digest('hex');
+    return digest;
+  } else {
+    const data = new TextEncoder().encode(input);
+    const digest = await window.crypto.subtle.digest('SHA-256', data);
+    const byteArray = new Uint8Array(digest);
+    const chars = new Array(byteArray.length);
+    byteArray.forEach((byte, index) => {
+      chars[index] = byte.toString(16).padStart(2, '0');
+    });
+    return chars.join('');
+  }
 }

--- a/test/crypto.server.test.ts
+++ b/test/crypto.server.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment node
+ */
+
+import { sha256, isCryptoSupported } from '../src/crypto';
+
+describe('sha256 server', () => {
+  test('supported', () => {
+    expect(isCryptoSupported()).toBe(true);
+  });
+
+  test('computes the hash', async () => {
+    const hash = await sha256('Hello world!');
+    expect(hash).toEqual(
+      'c0535e4be2b79ffd93291305436bf889314e4a3faec05ecffcbb7df31ad9e51a',
+    );
+  });
+});


### PR DESCRIPTION
This is a wonderful urql exchange but unfortunately can't create persisted queries in server environments like Next.js because it relies on the web crypto api.

This PR checks if `typeof window === "undefined"`, and if it is, hashes queries with node's crypto module.